### PR TITLE
Put NameIDFormat before AssertionConsumerService

### DIFF
--- a/src/templates/mellon-sp-metadata.xml
+++ b/src/templates/mellon-sp-metadata.xml
@@ -15,9 +15,9 @@
 		</KeyDescriptor>
 		{% endif %}
 		<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ options.sp_logout_url }}"/>
-		<AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{ options.sp_post_response_url }}" isDefault="true" index="0"/>
 		{% for format in options.supported_nameid_formats -%}
 		<NameIDFormat>{{ format }}</NameIDFormat>
 		{% endfor -%}
+		<AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{ options.sp_post_response_url }}" isDefault="true" index="0"/>
 	</SPSSODescriptor>
 </EntityDescriptor>


### PR DESCRIPTION
In SSODescriptorType NameIDFormat is specified first and then any
additional SP or IDP-specific elements are placed including
AssertionConsumerService. If this is not the case, schema validators
mark a metadata file as invalid.

https://wiki.shibboleth.net/confluence/display/CONCEPT/MetadataForSP
https://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd
See 2.4.2:
https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf