### PR TITLE
Standardize reactive practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.pyc
 build
 src/tests/bundles/overlays/local-charm-overlay.yaml.j2
+interfaces
+layers

--- a/src/README.md
+++ b/src/README.md
@@ -47,6 +47,7 @@ In a bundle:
           idp-name: 'samltest'
           protocol-name: 'mapped'
           user-facing-name: "samltest.id'
+          nameid-formats="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
         resources:
           idp-metadata: "./idp-metadata.xml"
           sp-signing-keyinfo: "./sp-keyinfo.xml"

--- a/src/lib/charm/openstack/keystone_saml_mellon.py
+++ b/src/lib/charm/openstack/keystone_saml_mellon.py
@@ -256,7 +256,7 @@ class KeystoneSAMLMellonCharm(charms_openstack.charm.OpenStackCharm):
         if not self.configuration_complete():
             errors = [
                 '{}: {}'.format(k, v)
-                for k, v in self.options.validation_errors.items() if v]
+                for k, v in self.options.validation_errors.items()]
             status_msg = 'Configuration is incomplete. {}'.format(
                 ','.join(errors))
             return 'blocked', status_msg

--- a/src/reactive/keystone_saml_mellon_handlers.py
+++ b/src/reactive/keystone_saml_mellon_handlers.py
@@ -13,16 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
-
 # import to trigger openstack charm metaclass init
-import charm.openstack.keystone_saml_mellon # noqa
+import charm.openstack.keystone_saml_mellon as keystone_saml_mellon  # noqa
 
 import charms_openstack.charm as charm
 import charms.reactive as reactive
-import charms.reactive.flags as flags
-
-import charmhelpers.core.unitdata as unitdata
 
 from charms.reactive.relations import (
     endpoint_from_flag,
@@ -30,34 +25,11 @@ from charms.reactive.relations import (
 
 charm.use_defaults(
     'charm.installed',
-    'update-status')
-
-# if config has been changed we need to re-evaluate flags
-# config.changed is set and cleared (atexit) in layer-basic
-flags.register_trigger(when='config.changed',
-                       clear_flag='config.rendered')
-flags.register_trigger(when='upgraded', clear_flag='config.rendered')
-flags.register_trigger(when='config.changed',
-                       clear_flag='config.complete')
-flags.register_trigger(
-    when='endpoint.keystone-fid-service-provider.changed',
-    clear_flag='keystone-data.complete'
-)
+    'update-status',
+    'upgrade-charm')
 
 
-@reactive.hook('upgrade-charm')
-def default_upgrade_charm():
-    """Default handler for the 'upgrade-charm' hook.
-    This calls the charm.singleton.upgrade_charm() function as a default.
-    """
-    reactive.set_state('upgraded')
-
-
-# clear the upgraded state once config.rendered is set again
-flags.register_trigger(when='config.rendered', clear_flag='upgraded')
-
-
-@reactive.when_not('endpoint.keystone-fid-service-provider.joined')
+@reactive.when_not('keystone-fid-service-provider.connected')
 def keystone_departed():
     """
     Service restart should be handled on the keystone side
@@ -67,69 +39,46 @@ def keystone_departed():
         charm_instance.remove_config()
 
 
-@reactive.when('endpoint.keystone-fid-service-provider.joined')
-@reactive.when_not('config.complete')
-def config_changed():
-    with charm.provide_charm_instance() as charm_instance:
-        if charm_instance.configuration_complete():
-            flags.set_flag('config.complete')
-
-
-@reactive.when('endpoint.keystone-fid-service-provider.joined')
-@reactive.when_not('keystone-data.complete')
-def keystone_data_changed(fid_sp):
-    primary_data = fid_sp.all_joined_units[0].received
-    if primary_data:
-        hostname = primary_data.get('hostname')
-        port = primary_data.get('port')
-        tls_enabled = primary_data.get('tls-enabled')
-        # a basic check on the fact that keystone provided us with
-        # hostname and port information
-        if hostname and port:
-            # save hostname and port data in local storage for future
-            # use - in case config is incomplete but a relation is
-            # we need to store this across charm hook invocations
-            unitdb = unitdata.kv()
-            unitdb.set('hostname', hostname)
-            unitdb.set('port', port)
-            unitdb.set('tls-enabled', tls_enabled)
-            flags.set_flag('keystone-data.complete')
-
-
-@reactive.when('endpoint.keystone-fid-service-provider.joined')
-@reactive.when('config.complete')
-@reactive.when('keystone-data.complete')
-@reactive.when_not('config.rendered')
-def render_config():
+@reactive.when('keystone-fid-service-provider.connected')
+def publish_sp_fid():
     # don't always have a relation context - obtain from the flag
     fid_sp = endpoint_from_flag(
-        'endpoint.keystone-fid-service-provider.joined')
+        keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
     with charm.provide_charm_instance() as charm_instance:
-        charm_instance.render_config()
-        flags.set_flag('config.rendered')
-        # Trigger keystone restart. The relation is container-scoped
-        # so a per-unit db of a remote unit will only contain a nonce
-        # of a single subordinate
-        restart_nonce = str(uuid.uuid4())
-        fid_sp.publish(restart_nonce,
-                       charm_instance.options.protocol_name,
+        fid_sp.publish(charm_instance.options.protocol_name,
                        charm_instance.options.remote_id_attribute)
 
 
-@reactive.when('endpoint.websso-fid-service-provider.joined')
-@reactive.when('config.complete')
-@reactive.when('keystone-data.complete')
-@reactive.when('config.rendered')
+@reactive.when('keystone-fid-service-provider.available')
+def render_config():
+    # don't always have a relation context - obtain from the flag
+    fid_sp = endpoint_from_flag(
+        keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
+    with charm.provide_charm_instance() as charm_instance:
+        if charm_instance.configuration_complete():
+            print("COMPLETE")
+            charm_instance.render_config()
+            # Trigger keystone restart. The relation is container-scoped
+            # so a per-unit db of a remote unit will only contain a nonce
+            # of a single subordinate
+            print("CHECK_anyfile")
+            if reactive.any_file_changed(keystone_saml_mellon.CONFIGS):
+                print("TRUE_anyfile")
+                fid_sp.request_restart()
+
+
+@reactive.when('websso-fid-service-provider.connected')
 def configure_websso():
     # don't always have a relation context - obtain from the flag
     websso_fid_sp = endpoint_from_flag(
-        'endpoint.websso-fid-service-provider.joined')
+        'websso-fid-service-provider.connected')
     with charm.provide_charm_instance() as charm_instance:
-        # publish config options for all remote units of a given rel
-        options = charm_instance.options
-        websso_fid_sp.publish(options.protocol_name,
-                              options.idp_name,
-                              options.user_facing_name)
+        if charm_instance.configuration_complete():
+            # publish config options for all remote units of a given rel
+            options = charm_instance.options
+            websso_fid_sp.publish(options.protocol_name,
+                                  options.idp_name,
+                                  options.user_facing_name)
 
 
 @reactive.when_not('always.run')

--- a/src/reactive/keystone_saml_mellon_handlers.py
+++ b/src/reactive/keystone_saml_mellon_handlers.py
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import to trigger openstack charm metaclass init
-import charm.openstack.keystone_saml_mellon as keystone_saml_mellon  # noqa
+import charms_openstack.bus
+charms_openstack.bus.discover()
+
 
 import charms_openstack.charm as charm
 import charms.reactive as reactive
-
-from charms.reactive.relations import (
-    endpoint_from_flag,
-)
 
 charm.use_defaults(
     'charm.installed',
@@ -41,9 +38,6 @@ def keystone_departed():
 
 @reactive.when('keystone-fid-service-provider.connected')
 def publish_sp_fid(fid_sp):
-    # don't always have a relation context - obtain from the flag
-    #fid_sp = endpoint_from_flag(
-    #    keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
     with charm.provide_charm_instance() as charm_instance:
         fid_sp.publish(charm_instance.options.protocol_name,
                        charm_instance.options.remote_id_attribute)
@@ -51,24 +45,18 @@ def publish_sp_fid(fid_sp):
 
 @reactive.when('keystone-fid-service-provider.available')
 def render_config(fid_sp):
-    # don't always have a relation context - obtain from the flag
-    #fid_sp = endpoint_from_flag(
-    #    keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
     with charm.provide_charm_instance() as charm_instance:
         if charm_instance.configuration_complete():
             charm_instance.render_config(fid_sp)
             # Trigger keystone restart. The relation is container-scoped
             # so a per-unit db of a remote unit will only contain a nonce
             # of a single subordinate
-            if reactive.any_file_changed(keystone_saml_mellon.CONFIGS):
+            if reactive.any_file_changed(charm_instance.restart_map.keys()):
                 fid_sp.request_restart()
 
 
 @reactive.when('websso-fid-service-provider.connected')
-def configure_websso():
-    # don't always have a relation context - obtain from the flag
-    websso_fid_sp = endpoint_from_flag(
-        'websso-fid-service-provider.connected')
+def configure_websso(websso_fid_sp):
     with charm.provide_charm_instance() as charm_instance:
         if charm_instance.configuration_complete():
             # publish config options for all remote units of a given rel

--- a/src/reactive/keystone_saml_mellon_handlers.py
+++ b/src/reactive/keystone_saml_mellon_handlers.py
@@ -40,30 +40,27 @@ def keystone_departed():
 
 
 @reactive.when('keystone-fid-service-provider.connected')
-def publish_sp_fid():
+def publish_sp_fid(fid_sp):
     # don't always have a relation context - obtain from the flag
-    fid_sp = endpoint_from_flag(
-        keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
+    #fid_sp = endpoint_from_flag(
+    #    keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
     with charm.provide_charm_instance() as charm_instance:
         fid_sp.publish(charm_instance.options.protocol_name,
                        charm_instance.options.remote_id_attribute)
 
 
 @reactive.when('keystone-fid-service-provider.available')
-def render_config():
+def render_config(fid_sp):
     # don't always have a relation context - obtain from the flag
-    fid_sp = endpoint_from_flag(
-        keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
+    #fid_sp = endpoint_from_flag(
+    #    keystone_saml_mellon.KEYSTONE_FID_ENDPOINT)
     with charm.provide_charm_instance() as charm_instance:
         if charm_instance.configuration_complete():
-            print("COMPLETE")
-            charm_instance.render_config()
+            charm_instance.render_config(fid_sp)
             # Trigger keystone restart. The relation is container-scoped
             # so a per-unit db of a remote unit will only contain a nonce
             # of a single subordinate
-            print("CHECK_anyfile")
             if reactive.any_file_changed(keystone_saml_mellon.CONFIGS):
-                print("TRUE_anyfile")
                 fid_sp.request_restart()
 
 

--- a/src/templates/mellon-sp-metadata.xml
+++ b/src/templates/mellon-sp-metadata.xml
@@ -1,5 +1,5 @@
 <EntityDescriptor
-	entityID="{{ options.sp_auth_url }}"
+	entityID="{{ keystone_fid_service_provider.base_url }}{{ options.sp_auth_path }}"
 	xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
 	<SPSSODescriptor
@@ -14,10 +14,10 @@
 			{{ options.sp_signing_keyinfo }}
 		</KeyDescriptor>
 		{% endif %}
-		<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ options.sp_logout_url }}"/>
+		<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ keystone_fid_service_provider.base_url }}{{ options.sp_logout_path }}"/>
 		{% for format in options.supported_nameid_formats -%}
 		<NameIDFormat>{{ format }}</NameIDFormat>
 		{% endfor -%}
-		<AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{ options.sp_post_response_url }}" isDefault="true" index="0"/>
+		<AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{ keystone_fid_service_provider.base_url }}{{ options.sp_post_response_path }}" isDefault="true" index="0"/>
 	</SPSSODescriptor>
 </EntityDescriptor>

--- a/unit_tests/test_keystone_saml_mellon_handlers.py
+++ b/unit_tests/test_keystone_saml_mellon_handlers.py
@@ -68,10 +68,7 @@ class TestKeystoneSAMLMellonHandlers(test_utils.PatchHelper):
         self.patch_object(handlers.reactive, 'any_file_changed',
                           new=mock.MagicMock())
 
-        self.patch_object(handlers, 'endpoint_from_flag',
-                          new=mock.MagicMock())
         self.endpoint = mock.MagicMock()
-        self.endpoint_from_flag.return_value = self.endpoint
 
         self.protocol_name = "mapped"
         self.remote_id_attribute = "https://samltest.id"
@@ -99,7 +96,7 @@ class TestKeystoneSAMLMellonHandlers(test_utils.PatchHelper):
         self.keystone_saml_mellon_charm.remove_config.assert_called_once_with()
 
     def test_publish_sp_fid(self):
-        handlers.publish_sp_fid()
+        handlers.publish_sp_fid(self.endpoint)
         self.endpoint.publish.assert_called_once_with(
             self.protocol_name, self.remote_id_attribute)
 
@@ -109,17 +106,18 @@ class TestKeystoneSAMLMellonHandlers(test_utils.PatchHelper):
         (self.keystone_saml_mellon_charm
             .configuration_complete.return_value) = True
 
-        handlers.render_config()
-        self.keystone_saml_mellon_charm.render_config.assert_called_once_with()
+        handlers.render_config(self.endpoint)
+        self.keystone_saml_mellon_charm.render_config.assert_called_once_with(
+            self.endpoint)
         self.endpoint.request_restart.assert_not_called()
 
         # Restart
         self.any_file_changed.return_value = True
-        handlers.render_config()
+        handlers.render_config(self.endpoint)
         self.endpoint.request_restart.assert_called_once_with()
 
     def test_configure_websso(self):
-        handlers.configure_websso()
+        handlers.configure_websso(self.endpoint)
         self.endpoint.publish.assert_called_once_with(
             self.protocol_name, self.idp_name, self.user_facing_name)
 

--- a/unit_tests/test_lib_charm_openstack_keystone_saml_mellon.py
+++ b/unit_tests/test_lib_charm_openstack_keystone_saml_mellon.py
@@ -45,13 +45,10 @@ class Helper(test_utils.PatchHelper):
         self.patch_release(
             keystone_saml_mellon.KeystoneSAMLMellonCharm.release)
 
-        self.patch_object(keystone_saml_mellon, 'unitdata',
+        self.patch_object(keystone_saml_mellon, 'endpoint_from_flag',
                           new=mock.MagicMock())
-        self.kv = mock.MagicMock()
-        self.unitdata.kv.return_value = self.kv
-
-        self.patch_object(keystone_saml_mellon.os_utils, 'os_release',
-                          new=mock.MagicMock())
+        self.endpoint = mock.MagicMock()
+        self.endpoint_from_flag.return_value = self.endpoint
 
         self.idp_name = "samltest"
         self.protocol_name = "mapped"
@@ -100,19 +97,6 @@ class Helper(test_utils.PatchHelper):
         self.open.return_value = self.fileobj
 
 
-class TestKeystoneSAMLMellonUtils(Helper):
-
-    def test_select_release(self):
-        self.kv.get.return_value = 'mitaka'
-        self.assertEqual(
-            keystone_saml_mellon.select_release(), 'mitaka')
-
-        self.kv.get.return_value = None
-        self.os_release.return_value = 'rocky'
-        self.assertEqual(
-            keystone_saml_mellon.select_release(), 'rocky')
-
-
 class TestKeystoneSAMLMellonConfigurationAdapter(Helper):
 
     def setUp(self):
@@ -120,12 +104,13 @@ class TestKeystoneSAMLMellonConfigurationAdapter(Helper):
         self.hostname = "keystone-sp.local"
         self.port = "5000"
         self.tls_enabled = True
-        self.unitdata_data = {
+        self.endpoint_data = {
             "hostname": self.hostname,
             "port": self.port,
             "tls-enabled": self.tls_enabled,
         }
-        self.kv.get.side_effect = FakeConfig(self.unitdata_data)
+        self.endpoint.all_joined_units.received.get.side_effect = (
+            FakeConfig(self.endpoint_data))
         self.base_url = "https://{}:{}".format(self.hostname, self.port)
 
     def test_validation_errors(self):
@@ -338,19 +323,20 @@ class TestKeystoneSAMLMellonCharm(Helper):
         self.sp_signing_keyinfo.__bool__.return_value = False
         self.assertFalse(ksm.configuration_complete())
 
-    def test_assess_status(self):
+    def test_custom_assess_status_check(self):
         ksm = keystone_saml_mellon.KeystoneSAMLMellonCharm()
-        ksm.assess_status()
-        self.application_version_set.asert_called_once_with()
-        self.status_set.assert_called_once_with("active", "Unit is ready")
+        self.assertEqual(
+            ksm.custom_assess_status_check(),
+            (None, None))
 
         # One option not ready
         self.status_set.reset_mock()
         self.sp_signing_keyinfo.__bool__.return_value = False
         ksm.options._validation_errors = {"idp-metadata": "malformed"}
-        ksm.assess_status()
-        self.status_set.assert_called_once_with(
-            "blocked", "Configuration is incomplete. idp-metadata: malformed")
+        self.assertEqual(
+            ksm.custom_assess_status_check(),
+            ("blocked",
+             "Configuration is incomplete. idp-metadata: malformed"))
 
     def test_render_config(self):
         ksm = keystone_saml_mellon.KeystoneSAMLMellonCharm()

--- a/unit_tests/test_lib_charm_openstack_keystone_saml_mellon.py
+++ b/unit_tests/test_lib_charm_openstack_keystone_saml_mellon.py
@@ -45,10 +45,7 @@ class Helper(test_utils.PatchHelper):
         self.patch_release(
             keystone_saml_mellon.KeystoneSAMLMellonCharm.release)
 
-        self.patch_object(keystone_saml_mellon, 'endpoint_from_flag',
-                          new=mock.MagicMock())
         self.endpoint = mock.MagicMock()
-        self.endpoint_from_flag.return_value = self.endpoint
 
         self.idp_name = "samltest"
         self.protocol_name = "mapped"
@@ -138,22 +135,6 @@ class TestKeystoneSAMLMellonConfigurationAdapter(Helper):
         self.assertEqual(
             ksmca.sp_private_key_file, keystone_saml_mellon.SP_PRIVATE_KEY)
 
-    def test_keystone_host(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(ksmca.keystone_host, self.hostname)
-
-    def test_keystone_port(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(ksmca.keystone_port, self.port)
-
-    def test_keystone_tls_enabled(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(ksmca.tls_enabled, self.tls_enabled)
-
-    def test_keystone_base_url(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(ksmca.keystone_base_url, self.base_url)
-
     def test_sp_idp_path(self):
         ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
         self.assertEqual(
@@ -194,25 +175,6 @@ class TestKeystoneSAMLMellonConfigurationAdapter(Helper):
         self.assertEqual(
             ksmca.sp_logout_path,
             '{}/logout'.format(ksmca.mellon_endpoint_path))
-
-    def test_sp_auth_url(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(
-            ksmca.sp_auth_url,
-            '{}{}'.format(ksmca.keystone_base_url, ksmca.sp_auth_path))
-
-    def test_sp_logout_url(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(
-            ksmca.sp_logout_url,
-            '{}{}'.format(ksmca.keystone_base_url, ksmca.sp_logout_path))
-
-    def test_sp_post_response_url(self):
-        ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()
-        self.assertEqual(
-            ksmca.sp_post_response_url,
-            '{}{}'.format(ksmca.keystone_base_url,
-                          ksmca.sp_post_response_path))
 
     def test_mellon_subject_confirmation_data_address_check(self):
         ksmca = keystone_saml_mellon.KeystoneSAMLMellonConfigurationAdapter()


### PR DESCRIPTION
Rely on updated interfaces.
Use standard practices for endpoint handling.
Remove unused code.

Depends on:
https://github.com/openstack-charmers/charm-interface-keystone-fid-service-provider/pull/1
https://github.com/openstack-charmers/charm-interface-websso-fid-service-provider/pull/1
