### PR TITLE
Remove zuul.yaml for gerrit

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,3 +1,0 @@
-- project:
-    templates:
-      - python35-charm-jobs


### PR DESCRIPTION
The zuul.yaml file cannot exist for the gerrit import process.
Temporarily remove it. We will re-add it after we get imported into
gerrit.